### PR TITLE
Moving alignment rrna depletion module to main branch for full data test

### DIFF
--- a/docs/content/align.rst
+++ b/docs/content/align.rst
@@ -7,6 +7,9 @@ Alignment
 | - Standard: The foundation of the pipeline used in XPRESSpipe is based in the `TCGA <https://docs.gdc.cancer.gov/Data/Bioinformatics_Pipelines/Expression_mRNA_Pipeline/>`_ standards for RNAseq alignment. This method utilizes a guided or 2-pass alignment program. In the guided alignment, a GTF with annotated splice junctions is used to guide the alignments over splice juntions. In the 2-pass alignment, reads are mapped across the genome to identify novel splice junctions. These new annotations are then incorporated into the reference index and reads are re-aligned with this new reference. While more time-intensive, this step can aid in aligning across these junctions, especially in organisms where the transcriptome is not as well annotated.
 | - Variant Aware: The user can provide a VCF, such as those provided by `ClinVar <ftp://ftp.ncbi.nih.gov/snp/organisms/human_9606/VCF/>`_ and `dbSNP <ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/>`_. These files are useful in integrating information about common or disease nucleotide variants into the RNA-Seq alignment stage. The files you use should match the build of the genome you are using (i.e., if using Homo Sapiens GRCh38, these builds should match between curated reference files and VCF file).
 
+.. note::
+  rRNA depletion using the :data:`--remove_rrna` option removes rRNA alignments from BAM files. This works by generating a BED file behind the scenes for rRNA transcripts, and removing them from the genome-aligned BAM file using :data:`bedtools intersect`. For transcriptome-aligned BAM files, a modified GTF file is generated for this step only with rRNA records removed in order to prevent their transcript mapping during this step. 
+
 ============================
 Single-End RNAseq Alignment
 ============================
@@ -47,6 +50,8 @@ Arguments
      - Description
    * - :data:`--two-pass`
      - Use a two-pass STAR alignment for novel splice junction discovery
+   * - :data:`--remove_rrna`
+     - Provide flag to remove rRNA records from alignment files (BAM files)
    * - :data:`--no_multimappers>`
      - Include flag to remove multimapping reads to be output and used in downstream analyses
    * - :data:`--deduplicate`

--- a/docs/content/peRNAseq.rst
+++ b/docs/content/peRNAseq.rst
@@ -1,7 +1,7 @@
 ############################
 Paired-End RNA-seq Pipeline
 ############################
-| The following pipeline will pre-process, align, and quality check paired-end RNA-seq samples using the sub-modules discussed in earlier chapters. For more detailed information concerning these steps, please refer to the appropriate chapter.
+| The following pipeline will pre-process, align, and quality check paired-end RNA-seq samples using the sub-modules discussed in earlier chapters. For more detailed information concerning these steps, please refer to the Align chapter.
 
 .. list-table::
    :widths: 35 50
@@ -34,6 +34,8 @@ Paired-End RNA-seq Pipeline
      - PHRED read quality threshold (default: :data:`28`)
    * - :data:`--min_length \<length_value\>`
      - Minimum read length threshold to keep for reads (default: :data:`17`)
+   * - :data:`--remove_rrna`
+     - Provide flag to remove rRNA records from alignment files (BAM files)
    * - :data:`--umi_location \<location\>`
      - Provide parameter to process UMIs -- provide location (see fastp documentation for more details, generally for single-end sequencing, you would provide 'read1' here; does not work with -a polyX option)
    * - :data:`--umi_length \<length\>`

--- a/docs/content/riboseq.rst
+++ b/docs/content/riboseq.rst
@@ -1,7 +1,7 @@
 ############################
 Ribosome Profiling Pipeline
 ############################
-| The following pipeline will pre-process, align, and quality check ribosome profiling samples using the sub-modules discussed in other sections of this documentation. For more detailed information concerning these steps, please refer to the appropriate chapter for the step you are interested in.
+| The following pipeline will pre-process, align, and quality check ribosome profiling samples using the sub-modules discussed in other sections of this documentation. For more detailed information concerning these steps, please refer to the Align chapter for the step you are interested in.
 
 .. list-table::
    :widths: 35 50
@@ -34,6 +34,8 @@ Ribosome Profiling Pipeline
      - PHRED read quality threshold (default: :data:`28`)
    * - :data:`--min_length \<length_value\>`
      - Minimum read length threshold to keep for reads (default: :data:`17`)
+   * - :data:`--remove_rrna`
+     - Provide flag to remove rRNA records from alignment files (BAM files)
    * - :data:`--umi_location \<location\>`
      - Provide parameter to process UMIs -- provide location (see fastp documentation for more details, generally for single-end sequencing, you would provide 'read1' here; does not work with -a polyX option)
    * - :data:`--umi_length \<length\>`

--- a/docs/content/seRNAseq.rst
+++ b/docs/content/seRNAseq.rst
@@ -1,7 +1,7 @@
 ############################
 Single-End RNA-seq Pipeline
 ############################
-| The following pipeline will pre-process, align, and quality check single-end RNA-seq samples using the sub-modules discussed in earlier chapters. For more detailed information concerning these steps, please refer to the appropriate chapter.
+| The following pipeline will pre-process, align, and quality check single-end RNA-seq samples using the sub-modules discussed in earlier chapters. For more detailed information concerning these steps, please refer to the Align chapter.
 
 .. list-table::
    :widths: 35 50
@@ -34,6 +34,8 @@ Single-End RNA-seq Pipeline
      - PHRED read quality threshold (default: :data:`28`)
    * - :data:`--min_length \<length_value\>`
      - Minimum read length threshold to keep for reads (default: :data:`17`)
+   * - :data:`--remove_rrna`
+     - Provide flag to remove rRNA records from alignment files (BAM files)
    * - :data:`--umi_location \<location\>`
      - Provide parameter to process UMIs -- provide location (see fastp documentation for more details, generally for single-end sequencing, you would provide 'read1' here; does not work with -a polyX option)
    * - :data:`--umi_length \<length\>`

--- a/docs/content/updates.rst
+++ b/docs/content/updates.rst
@@ -2,10 +2,17 @@
 Updates
 ###############
 
+========================
+v0.4.0 (in progress)
+========================
+- Introduced rRNA depletion during alignment step (previously could only do so during the quantification step)
+- Expanded periodicity analysis to report codon usage stats, etc. (in progress)
+
+
 ============
 v0.3.1
 ============
-- Fix BAM file threshold for metagene and geneCoverage to avoid OOM errors 
+- Fix BAM file threshold for metagene and geneCoverage to avoid OOM errors
 - Turn off BAM file threshold for counting (low memory footprint, so can use all cores available)
 - Import openssl library manually in Rperiodicity -- occasionally had trouble finding the library on its own and would error
 

--- a/xpresspipe/__init__.py
+++ b/xpresspipe/__init__.py
@@ -19,7 +19,7 @@ You should have received a copy of the GNU General Public License along with
 this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-__version__ = '0.3.1'
+__version__ = '0.4.0'
 
 from .__main__ import *
 from .align import *

--- a/xpresspipe/arguments.py
+++ b/xpresspipe/arguments.py
@@ -495,6 +495,11 @@ def get_arguments(
         default = DEFAULT_READ_MIN,
         required = False)
     se_opts.add_argument(
+        '--remove_rrna',
+        help = 'Include option to remove rRNA alignments during alignment step',
+        action = 'store_true',
+        required = False)
+    se_opts.add_argument(
         '--umi_location',
         help = 'Provide parameter to process UMIs -- provide location (see fastp documentation for more details, generally for single-end sequencing, you would provide \'read1\' here; does not work with -a polyX option)',
         metavar = '<location>',
@@ -686,6 +691,11 @@ def get_arguments(
         default = DEFAULT_READ_MIN,
         required = False)
     pe_opts.add_argument(
+        '--remove_rrna',
+        help = 'Include option to remove rRNA alignments during alignment step',
+        action = 'store_true',
+        required = False)
+    pe_opts.add_argument(
         '--umi_location',
         help = 'Provide parameter to process UMIs -- provide location (see fastp documentation for more details, generally for single-end sequencing, you would provide \'read1\' here; does not work with -a polyX option)',
         metavar = '<location>',
@@ -873,6 +883,11 @@ def get_arguments(
         metavar = '<length_value>',
         type = int,
         default = DEFAULT_READ_MIN,
+        required = False)
+    rp_opts.add_argument(
+        '--remove_rrna',
+        help = 'Include option to remove rRNA alignments during alignment step',
+        action = 'store_true',
         required = False)
     rp_opts.add_argument(
         '--umi_location',
@@ -1099,6 +1114,11 @@ def get_arguments(
     align_opts.add_argument(
         '--two-pass',
         help = 'Use a two-pass STAR alignment for novel splice junction discovery',
+        action = 'store_true',
+        required = False)
+    align_opts.add_argument(
+        '--remove_rrna',
+        help = 'Include option to remove rRNA alignments during alignment step',
         action = 'store_true',
         required = False)
     align_opts.add_argument(

--- a/xpresspipe/compile.py
+++ b/xpresspipe/compile.py
@@ -42,7 +42,6 @@ from .utils import add_directory
 input_count = 'coverage'
 window = 20
 
-"""Compile images from a list of metrics matrices"""
 def compile_matrix_metrics(
         path,
         file_list,
@@ -52,6 +51,8 @@ def compile_matrix_metrics(
         experiment,
         plot_output,
         dpi=600):
+    """Compile images from a list of metrics matrices"""
+
 
     # Keep axes happy to avoid 'IndexError: too many indices for array' error
     # Auto formats figure summary size based on number of plots
@@ -486,7 +487,7 @@ def compile_coverage(
             axes[ax_y].axvline(index, ls='-', linewidth=3, color='black', ymin=0, ymax=0.75)
             df.at[df.index[-1] - 1, 'feature'] = 'CDS Stop'
             stop_written = True
-            
+
         # If last nt, add closing line
         elif index == df.index[-1] - 1:
             axes[ax_y].axvline(index, ls='-', linewidth=5, color='#585555', ymin=0, ymax=0.5)

--- a/xpresspipe/complexity.py
+++ b/xpresspipe/complexity.py
@@ -32,9 +32,9 @@ from .utils import add_directory, get_files
 
 __path__ = str(os.path.dirname(os.path.realpath(__file__))) + '/'
 
-"""Measure library complexity"""
 def run_complexity(
         args):
+    """Measure library complexity"""
 
     file, args_dict = args[0], args[1]
 
@@ -55,8 +55,9 @@ def run_complexity(
         + ' ' + str(args_dict['complexity']) + 'metrics/' + str(file).rsplit('.',1)[0] + '_metrics.txt'
         + str(args_dict['log']))
 
-"""Manager for running complexity summary plotting"""
+
 def make_complexity(args_dict):
+    """Manager for running complexity summary plotting"""
 
     print('\nRunning complexity analysis of sequence libraries...')
 

--- a/xpresspipe/count.py
+++ b/xpresspipe/count.py
@@ -139,10 +139,10 @@ def count_reads(
             'abundances')
 
         parallelize(
-        count_file_cufflinks,
-        files,
-        args_dict,
-        mod_workers = 'all')
+            count_file_cufflinks,
+            files,
+            args_dict,
+            mod_workers = 'all')
 
     else:
 
@@ -153,10 +153,10 @@ def count_reads(
             'counts')
 
         parallelize(
-        count_file_htseq,
-        files,
-        args_dict,
-        mod_workers = 'all')
+            count_file_htseq,
+            files,
+            args_dict,
+            mod_workers = 'all')
 
     return args_dict
 

--- a/xpresspipe/rrna_depletion.py
+++ b/xpresspipe/rrna_depletion.py
@@ -1,0 +1,134 @@
+"""
+XPRESSpipe
+An alignment and analysis pipeline for RNAseq data
+alias: xpresspipe
+
+Copyright (C) 2019  Jordan A. Berg
+jordan <dot> berg <at> biochem <dot> utah <dot> edu
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+from __future__ import print_function
+
+"""IMPORT DEPENDENCIES"""
+import os
+import re
+import csv
+import gc
+import pandas as pd
+
+"""IMPORT INTERNAL DEPENDENCIES
+"""
+from .utils import get_files
+from .parallel import parallelize
+
+gtf_type_column = 2
+gtf_annotation_column = 8
+search_type = 'transcript'
+parse_type = 'rrna'
+
+def generate_bed(
+        gtf_file):
+    """Generate a BED file of rRNA sequences for depletion from genome-aligned
+    BAM file.
+    """
+
+    # Set up BED generation command
+    gtf = pd.read_csv(
+        str(gtf_file),
+        sep = '\t',
+        header = None,
+        comment = '#',
+        low_memory = False)
+
+    # Remove records that map to rRNA
+    gtf_rrna = gtf[gtf[gtf_annotation_column].str.contains(
+        parse_type, flags=re.IGNORECASE
+        )]
+    gtf_rrna = gtf.loc[gtf[gtf_type_column] == search_type]
+
+    bed_file = gtf_file[:-4] + '_rrna.bed'
+
+    gtf_rrna.to_csv(
+        str(bed_file),
+        sep = '\t',
+        header = None,
+        index = False,
+        quoting = csv.QUOTE_NONE)
+
+    gtf = None # Garbage management
+    gtf_rrna = None
+    gc.collect()
+
+    return bed_file
+
+def run_intersect(
+        args):
+    """Use rRNA BED file to extract the inverse intersection of alignments
+    args[0] = alignment file directory
+    args[1] = bam_file of interest
+    args[2] = bed_file for reference
+    """
+
+    file_iterator, args_dict = args[0], args[1]
+    dir, bam_file, bed_file = file_iterator[0], file_iterator[1], file_iterator[2]
+
+    # Set up intersection command
+    cmd = (
+        'bedtools intersect -abam ' + dir + bam_file
+        + ' -b ' + bed_file
+        + ' -v > ' + dir + bam_file + '.depl'
+    )
+
+    # Run
+    os.system(cmd)
+
+    os.system(
+        'mv '
+        + dir + bam_file + '.depl'
+        + ' ' + dir + bam_file
+    )
+
+def genomic_depletion(
+        args_dict,
+        dir='alignments_coordinates',
+        suffix='_Aligned.sort.bam'):
+    """Remove rRNA records from genome-aligned BAM file
+
+    Usage:
+    - Access gtf file via:
+        str(args_dict['reference']) + 'transcripts.gtf'
+    - Access genome-aligned files via:
+        str(args_dict['alignments_coordinates'])
+    * file_list should already have path appended
+    """
+
+    gtf_file = str(args_dict['reference']) + 'transcripts.gtf'
+    bed_file = generate_bed(
+        gtf_file=gtf_file)
+
+    # Get list of files to count based on acceptable file types
+    file_list = get_files(
+        args_dict[dir],
+        [str(suffix)])
+
+    file_iterator = []
+    for file in file_list:
+
+        file_iterator.append([args_dict[dir], file, bed_file])
+
+    parallelize(
+        run_intersect,
+        file_iterator,
+        args_dict,
+        mod_workers = 'all')


### PR DESCRIPTION
Includes new flag for alignment steps, `--remove_rrna`.
Previously, rRNA depletion could only occur during quantification by providing a GTF file with only protein-coding genes. 
This new flag allows for the removal of rRNA during alignment in two ways:
1. Genome alignment: Use `bedtools intersect` to remove records that fall in rRNA regions
2. Use a GTF during alignment BAM file conversion to transcriptome file that has rRNA records removed so these will not be counted as mapped transcripts